### PR TITLE
【開発】Google認証機能の実装

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -9,6 +9,7 @@ use App\Providers\RouteServiceProvider;
 use Illuminate\Validation\ValidationException;
 use Aws\CognitoIdentityProvider\Exception\CognitoIdentityProviderException;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use App\Http\Services\CreateGoogleAuthUrl;
 
 class LoginController extends Controller
 {
@@ -42,17 +43,10 @@ class LoginController extends Controller
         $this->middleware('auth')->only('logout');
     }
 
-    public function showLoginForm() {
-        $params = [
-            '{domain_name}' => config('cognito.domain_name'),
-            '{region}' => config('cognito.region'),
-            '{app_client_id}' => config('cognito.app_client_id'),
-            '{redirect_url}' => 'http://localhost:8080/home'
-        ];
+    public function showLoginForm(CreateGoogleAuthUrl $createGoogleAuthUrl) {
+        $authUrl = $createGoogleAuthUrl->execute();
 
-        $authURL = str_replace(array_keys($params), array_values($params), config('cognito.google_auth_url') );
-
-        return view("auth.login")->with(['authUrl' => $authURL ]);
+        return view("auth.login")->with(['authUrl' => $authUrl ]);
     }
 
     public function login(Request $request)

--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -43,7 +43,16 @@ class LoginController extends Controller
     }
 
     public function showLoginForm() {
-        return view("auth.login");
+        $params = [
+            '{domain_name}' => config('cognito.domain_name'),
+            '{region}' => config('cognito.region'),
+            '{app_client_id}' => config('cognito.app_client_id'),
+            '{redirect_url}' => 'http://localhost:8080/home'
+        ];
+
+        $authURL = str_replace(array_keys($params), array_values($params), config('cognito.google_auth_url') );
+
+        return view("auth.login")->with(['authUrl' => $authURL ]);
     }
 
     public function login(Request $request)

--- a/src/app/Http/Services/CreateGoogleAuthUrl.php
+++ b/src/app/Http/Services/CreateGoogleAuthUrl.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Services;
+
+class CreateGoogleAuthUrl
+{
+    public function execute()
+    {
+        $params = [
+            '{domain_name}' => config('cognito.domain_name'),
+            '{region}' => config('cognito.region'),
+            '{client_id}' => config('cognito.app_client_id'),
+            '{redirect_url}' => 'http://localhost:8080/home'
+        ];
+
+        return str_replace(array_keys($params), array_values($params), config('cognito.google_auth_url') );
+    }
+}

--- a/src/config/cognito.php
+++ b/src/config/cognito.php
@@ -7,5 +7,5 @@ return [
     'app_client_secret' =>   env('AWS_COGNITO_CLIENT_SECRET'), // 作成したクライアントシークレット
     'user_pool_id'      =>  env('AWS_COGNITO_USER_POOL_ID'), // ユーザープールのID
     'domain_name'       =>  env('AWS_COGNITO_DOMAIN_NAME'),
-    'google_auth_url'  => "https://{domain_name}.auth.{region}.amazoncognito.com/oauth2/authorize?client_id={app_client_id}&response_type=code&scope=email+openid+profile&redirect_uri={redirect_url}&identity_provider=Google"
+    'google_auth_url'  => "https://{domain_name}.auth.{region}.amazoncognito.com/oauth2/authorize?identity_provider=Google&redirect_uri={redirect_url}&response_type=CODE&client_id={client_id}&scope=email openid"
 ];

--- a/src/config/cognito.php
+++ b/src/config/cognito.php
@@ -5,5 +5,7 @@ return [
     'version'           =>  'latest',
     'app_client_id'     =>  env('AWS_COGNITO_CLIENT_ID'), // 作成したクライアントID
     'app_client_secret' =>   env('AWS_COGNITO_CLIENT_SECRET'), // 作成したクライアントシークレット
-    'user_pool_id'      =>  env('AWS_COGNITO_USER_POOL_ID') // ユーザープールのID
+    'user_pool_id'      =>  env('AWS_COGNITO_USER_POOL_ID'), // ユーザープールのID
+    'domain_name'       =>  env('AWS_COGNITO_DOMAIN_NAME'),
+    'google_auth_url'  => "https://{domain_name}.auth.{region}.amazoncognito.com/oauth2/authorize?client_id={app_client_id}&response_type=code&scope=email+openid+profile&redirect_uri={redirect_url}&identity_provider=Google"
 ];

--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -8,7 +8,7 @@
                 <div class="card-header">{{ __('Login') }}</div>
 
                 <div class="card-body">
-                    <form method="POST" action="{{ route('login') }}">
+                    <form method="POST" action="{{ route('login') }}" class="mb-3 border-bottom">
                         @csrf
 
                         <div class="row mb-3">
@@ -51,7 +51,7 @@
                             </div>
                         </div>
 
-                        <div class="row mb-0">
+                        <div class="row mb-3">
                             <div class="col-md-8 offset-md-4">
                                 <button type="submit" class="btn btn-primary">
                                     {{ __('Login') }}
@@ -65,6 +65,13 @@
                             </div>
                         </div>
                     </form>
+
+                    <div class="mb-3 justify-content-center">
+                        <a class="btn btn-danger col-12" href="{{$authUrl}}">
+                            <i class="fab fa-google"></i>
+                            Googleアカウントでログイン
+                        </a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -18,6 +18,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.4/css/all.css">
+    <script defer src="https://use.fontawesome.com/releases/v5.15.4/js/all.js"></script>
+
     <!-- Scripts -->
     @vite(['resources/sass/app.scss', 'resources/js/app.js'])
 </head>


### PR DESCRIPTION
## お世話になった記事

- [CognitoユーザープールにGoogle認証を追加する手順](https://qiita.com/Naoki1126/items/2dbc8ac4eb07310adc0f)
- [Amazon CognitoのホストされたUIを表示しないIDフェデレーション](https://qiita.com/ta__k0/items/7af50df655a1812a2fc3)

## 確認方法

- ログインページ(/login)の「Googleアカウントでログイン」をタップする

<img width="494" alt="スクリーンショット 2024-08-21 23 28 22" src="https://github.com/user-attachments/assets/337b6de7-4719-49cb-bbb1-11ce297ec558">

- Googleの認証ページに遷移する

<img width="1307" alt="スクリーンショット 2024-08-21 15 52 58" src="https://github.com/user-attachments/assets/8eb43ba7-31f3-42b2-811e-02a663957f98">

- Cognitoのユーザー一覧を確認。Googleアカウントのメールアドレスが登録済みになっている

<img width="790" alt="スクリーンショット 2024-08-21 23 29 09" src="https://github.com/user-attachments/assets/e646e85d-a42c-48c9-98ce-af9b7c1ffb8c">

## 課題

- Googleアカウントがcognitoに登録された後に、もう一度「Googleアカウントでログイン」をタップすると、/homeにリダイレクトされるような仕組みを整える。
- usersテーブルに新しく「auth_medthod」カラムを追加する。
- Cognitoのサインアップ時に発火するlambdaの処理も下手したら変えないといけないかも・・・（https://docs.aws.amazon.com/ja_jp/cognito/latest/developerguide/user-pool-lambda-post-confirmation.html）

