### PR TITLE
【バグ修正】S3保存時のバグを修正する

### DIFF
--- a/src/app/Http/Services/Profile/DeleteProfileImage.php
+++ b/src/app/Http/Services/Profile/DeleteProfileImage.php
@@ -3,13 +3,19 @@
 namespace App\Http\Services\Profile;
 
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 
 class DeleteProfileImage
 {
     public function execute()
     {
         $user = Auth::user();
+        $profileImageKey = $user->profile_image_key;
+
+        $user->profile_image_url = null;
         $user->profile_image_key = null;
         $user->save();
+
+        Storage::disk('s3')->delete($profileImageKey);
     }
 }

--- a/src/app/Http/Services/Profile/UpdateProfileImage.php
+++ b/src/app/Http/Services/Profile/UpdateProfileImage.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Facades\Storage;
 
 class UpdateProfileImage
 {
+    /**
+     * @param string|null $path
+     * @return void
+     */
     public function execute(?string $path)
     {
         $randomStr = base_convert(md5(uniqid()), 16,36);
@@ -17,11 +21,26 @@ class UpdateProfileImage
         $s3Path = Storage::disk('s3')->url($fileName);
 
         $user = Auth::user();
+        $oldProfileImageKey = $user->profile_image_key;
+
         $user->profile_image_url = $s3Path;
         $user->profile_image_key = $fileName;
         $user->save();
 
+        if($oldProfileImageKey !== $fileName) {
+            $this->deleteUploadedImage($oldProfileImageKey);
+        }
+
         # S3への保存が成功したらWebサーバー上の一時ファイルを削除
         Storage::delete($path);
+    }
+
+    /**
+     * @param $oldImageKey
+     * @return void
+     */
+    public function deleteUploadedImage($oldImageKey) :void
+    {
+        Storage::disk('s3')->delete($oldImageKey);
     }
 }

--- a/src/app/Http/Services/Profile/UpdateProfileImage.php
+++ b/src/app/Http/Services/Profile/UpdateProfileImage.php
@@ -9,14 +9,16 @@ class UpdateProfileImage
 {
     public function execute(?string $path)
     {
+        $randomStr = base_convert(md5(uniqid()), 16,36);
+        $fileName = $randomStr.'.png';
 
         $fileContents = Storage::get($path);
-
-        Storage::disk('s3')->put('test2.png', $fileContents);
-        $s3Path = Storage::disk('s3')->temporaryUrl('test2.png', now()->addMinutes(5));
+        Storage::disk('s3')->put($fileName, $fileContents);
+        $s3Path = Storage::disk('s3')->url($fileName);
 
         $user = Auth::user();
-        $user->profile_image_key = $s3Path;
+        $user->profile_image_url = $s3Path;
+        $user->profile_image_key = $fileName;
         $user->save();
 
         # S3への保存が成功したらWebサーバー上の一時ファイルを削除

--- a/src/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/src/database/migrations/2014_10_12_000000_create_users_table.php
@@ -18,6 +18,7 @@ return new class extends Migration
             $table->string('cognito_username')->unique();
             $table->string('name',20)->nullable();
             $table->string('email')->unique();
+            $table->text('profile_image_url')->nullable();
             $table->text('profile_image_key')->nullable();
             $table->timestamps();
         });

--- a/src/resources/views/profile.blade.php
+++ b/src/resources/views/profile.blade.php
@@ -14,10 +14,11 @@
                 <h2 class="text-dark border-bottom">Profile</h2>
                 <div class="position-relative mb-3">
                     <img
-                        src="{{ $user->profile_image_key ? asset($user->profile_image_key): asset('img/profile_female.png') }}"
+                        src="{{ $user->profile_image_url ? asset($user->profile_image_url): asset('img/profile_female.png') }}"
                         onerror="this.onerror=null; this.src='{{ asset('img/profile_female.png')  }}';"
-                        width="80%"
-                        height="auto"
+                        class="thumbnail"
+                        width="300"
+                        height="300"
                     >
                     <div class="dropdown position-absolute color-bg-defaultcolor-fg-default px-2 py-1 left-0 bottom-0 ml-2 mb-2">
                         <button class="btn btn-light dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -212,5 +213,10 @@
     .alert{
         margin-bottom: 0px !important;
         border-radius: 0 !important;
+    }
+
+    .thumbnail {
+        object-fit: cover;
+        border-radius: 50%;
     }
 </style>


### PR DESCRIPTION
## やったこと


- プロフィール画像のレイアウトを調整する
⇨ 300 * 300固定, 中央でトリミング

```
 .thumbnail {
        object-fit: cover;
        border-radius: 50%;
    }
```

- 保存した画像の保存先URLを署名付きでないものに変更する

```
$s3Path = Storage::disk('s3')->temporaryUrl('test2.png', now()->addMinutes(5));
```
↓
```
$s3Path = Storage::disk('s3')->url($fileName);
```

- バケットポリシーを変更する

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": "*",
            "Action": "s3:GetObject",
            "Resource": "arn:aws:s3:::your-bucket-name/*",
            "Condition": {
                "IpAddress": {
                    "aws:SourceIp": [
                        "127.0.0.1/32",  # localhost
                        "203.0.113.0/24" # EC2 インスタンスの IP アドレス範囲
                    ]
                }
            }
        }
    ]
}
```

- S3の容量を食わないよう、プロフィール画像をデフォルトのものにリセットする際はS3のオブジェクトも削除するようにする

## 結果

<img width="849" alt="スクリーンショット 2024-08-29 20 09 19" src="https://github.com/user-attachments/assets/8125237e-98eb-4c73-b310-18ea0058dd3a">


